### PR TITLE
Adding a filter option when dumping or saving an ontology and its individuals

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -61,7 +61,7 @@ class BaseGraph(object):
   
   def parse(self, f): raise NotImplementedError
     
-  def save(self, f, format = "pretty-xml"): raise NotImplementedError
+  def save(self, f, format = "pretty-xml", filter=None): raise NotImplementedError
   
   def _abbreviate  (self, iri, create_if_missing = True): return iri
   def _unabbreviate(self, iri): return iri
@@ -238,11 +238,13 @@ def _guess_format(f):
   return "rdfxml"
 
 
-def _save(f, format, graph):
+def _save(f, format, graph, filter=None):
   if   format == "ntriples":
     _unabbreviate = lru_cache(None)(graph._unabbreviate)
     
     for s,p,o,d in graph._iter_triples():
+      if filter and callable(filter) and not filter(graph, s, p, o, d):
+        continue
       if   s < 0: s = "_:%s" % (-s)
       else:       s = "<%s>" % _unabbreviate(s)
       p = "<%s>" % _unabbreviate(p)
@@ -263,6 +265,8 @@ def _save(f, format, graph):
     c_2_iri = { c : iri for c, iri in graph._iter_ontology_iri() }
     
     for c,s,p,o,d in graph._iter_triples(True):
+      if filter and callable(filter) and not filter(graph, s, p, o, d, c):
+        continue
       if   s < 0: s = "_:%s" % (-s)
       else:       s = "<%s>" % _unabbreviate(s)
       p = "<%s>" % _unabbreviate(p)
@@ -423,6 +427,8 @@ def _save(f, format, graph):
     s_lines   = []
     current_s = ""
     for s,p,o,d in graph._iter_triples(False, True):
+      if filter and callable(filter) and not filter(graph, s, p, o, d):
+        continue
       if s != current_s:
         if current_s: purge()
         current_s = s
@@ -518,3 +524,4 @@ def _save(f, format, graph):
     
 
     f.write(b"""\n\n</rdf:RDF>\n""")
+


### PR DESCRIPTION
Following [this question in the mailing list](http://owlready.8326.n8.nabble.com/Saving-only-elements-of-the-ontology-used-by-the-individuals-td1566.html), I've decided to implement the feature. I'm adding a new `filter` parameter option to the `dump` and `save` operations so only those individuals for which the `filter` function returns `True` are exported. With the new `filter` parameter, now the user can select what elements to export in a `dump` or `save` operation.

For example, a valid `filter` function could be a function that returns `True` for those individuals that are an instance of a specific class:
```python
# Let's just keep the individuals of the classes we are interested in
def filter_func(graph, s, *args):
    classes = [graph.onto.Line, graph.onto.Word, graph.onto.Syllable]
    return (s >= 0 and any(isinstance(graph.onto.world._get_by_storid(s), cls)
                           for cls in classes))
```
Then, when saving, we just need to pass in the function as a parameter:
```python
onto.save(file="file.xml", format="rdfxml", filter=filter_func)
```