### PR TITLE
Update reasoning.py

### DIFF
--- a/reasoning.py
+++ b/reasoning.py
@@ -139,8 +139,12 @@ def sync_reasoner_hermit(x = None, infer_property_values = False, debug = 1, kee
         raise OwlReadyInconsistentOntologyError()
       else:
         raise OwlReadyJavaError("Java error message is:\n%s" % (e.stderr or e.output or b"").decode("utf8"))
-      
-    output = output.decode("utf8").replace("\r","")
+
+    try:
+      output = output.decode("utf8").replace("\r","")
+    except UnicodeDecodeError:
+      output = output.decode("latin").replace("\r","")    
+    
     if debug:
       print("* Owlready2 * HermiT took %s seconds" % (time.time() - t0), file = sys.stderr)
       if debug > 1:


### PR DESCRIPTION
Commit to add a try-except block  to check for latin encoding in the sync_reasoner_hermit function (without the commit I get an encoding error on my pc)